### PR TITLE
use ES5 where possible, removed duplicate declaration of errors

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -1,15 +1,4 @@
-var each = require('std/each')
-
-module.exports = {
-	NoError: 0,
-	OffsetOutOfRange: 1,
-	InvalidMessage: 2,
-	WrongPartition: 3,
-	InvalidRetchSize:4
-}
-
-each(['NoError', 'OffsetOutOfRange', 'InvalidMessage', 'WrongPartition', 'InvalidRetchSize'], function(name, codeNum) {
-	module.exports[name] = codeNum
-	module.exports[codeNum] = name
-})
-
+['NoError', 'OffsetOutOfRange', 'InvalidMessage', 'WrongPartition', 'InvalidRetchSize'].forEach(function(name, codeNum) {
+	module.exports[name] = codeNum;
+	module.exports[codeNum] = name;
+});


### PR DESCRIPTION
I might be missing something, but why aren't you just using ES5?

Also, why were these errors defined twice?

This simple pull should solve these "issues".
