### PR TITLE
Catch the error event emitted by net.createConnection

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -19,6 +19,7 @@ module.exports = std.Class(events.EventEmitter, function() {
 		if (this._connection) { throw new Error("connect called twice") }
 		this._connection = net.createConnection(this._port, this._host)
 		this._connection.on('connect', std.bind(this, 'emit', 'connect'))
+		this._connection.on('error', std.bind(this, 'emit', 'error'))
 		if (callback != undefined) this._connection.on('connect', callback)
 		return this
 	}


### PR DESCRIPTION
Catch the 'error' event emitted by net.createConnection and propagate it as our own 'error' event otherwise it may crash the node process
