### PR TITLE
package.json: add std to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     }
   ],
   "main": "kafka",
+  "dependencies": {
+    "std": "0.1.18"
+  },
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
if you add kafka as a dependency to a project it doesn't work because
std is missing, if you install the latest std it doesn't work because
_init is now init via std commit 02e278b0.

Start by fixing up the dependency in the package.json.
