### PR TITLE
unsubscribeTopic on consumer is not removing it 

### DIFF
--- a/lib/Consumer.js
+++ b/lib/Consumer.js
@@ -39,7 +39,7 @@ module.exports = std.Class(Client, function(supr) {
 	}
 
 	this.unsubscribeTopic = function(name) {
-		this._topics = this._topics.filter(function(x) { return x.name == name })
+		this._topics = this._topics.filter(function(x) { return x.name != name })
 		if (this._topics.length == 0) this._unschedulePoll()
 		return this
 	}


### PR DESCRIPTION
Calling unsubscribeTopic on a consumer is not removing it from _topics array  as the filter criteria used is not removing the topic from the _topics array.

subscribe --> unsubsribe --> subscribe to the same channel results in consumer object emitting 'message' event indefinetly.

If filter criteria equality is modified to inequality , the problem does not surface.

thanks
